### PR TITLE
🐛 [Bug fix]: Component.mdxの破損リンクを相対パスに修正

### DIFF
--- a/website/docs/Component/Component.mdx
+++ b/website/docs/Component/Component.mdx
@@ -13,14 +13,14 @@ Figma では、ボタンやテキストフィールドなど、よく使用す�
   <Card
     title="作成方法"
     description="コンポーネントの基本的な作成手順を学びます。フレームの作成からコンポーネント化まで、ステップバイステップで説明します。"
-    link="/docs/Component/01_作成方法"
+    link="./作成方法"
     size="medium"
   />
 
   <Card
     title="使用方法"
     description="作成したコンポーネントの使用方法を学びます。アセットパネルからの配置やインスタンスの編集について説明します。"
-    link="/docs/Component/02_使用方法"
+    link="./使用方法"
     size="medium"
   />
 </div>


### PR DESCRIPTION
## 概要

Docusaurusビルド時に発生していた破損リンクエラーを修正しました。

## 問題

- `yarn build`実行時に以下のエラーが発生
- Component.mdxファイルで日本語ファイル名への絶対パス参照により、URLエンコードの問題でリンクが破損

```
Error: Docusaurus found broken links!
- Broken link on source page path = /figma-memo/Component/:
   -> linking to /figma-memo/docs/Component/01_作成方法
   -> linking to /figma-memo/docs/Component/02_使用方法
```

## 解決方法

Component.mdxファイルのリンクを絶対パスから相対パスに変更：

- `/docs/Component/01_作成方法` → `./作成方法`
- `/docs/Component/02_使用方法` → `./使用方法`

この変更により、Buttonフォルダと同じパターンでのリンク参照となり、日本語ファイル名でも正常に動作するようになりました。

## 検証

- ✅ `yarn build`が正常に完了することを確認
- ✅ リンクが正しく機能することを確認

## 影響範囲

- `website/docs/Component/Component.mdx`のみ